### PR TITLE
[FOR-UPSTREAM] Avoid linking the snmalloc shim against the C++ stdlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,12 @@ if(NOT DEFINED SNMALLOC_ONLY_HEADER_LIBRARY)
     if(EXPOSE_EXTERNAL_RESERVE)
       target_compile_definitions(${name} PRIVATE -DSNMALLOC_EXPOSE_RESERVE)
     endif()
+
+    # Avoid linking against the C++ standard library. This is especially
+    # important when trying to use snmalloc with LD_PRELOAD on a minimal
+    # OS image that does not have a C++ library installed.
+    set_target_properties(${name} PROPERTIES LINKER_LANGUAGE C)
+
   endmacro()
 
   if(NOT MSVC)


### PR DESCRIPTION
We are not using any C++ symbols and linking against libc should be sufficient.
To achieve this we can tell CMake to link with cc instead of c++ by
settisetting the LINKER_LANGUAGE property to C.
This is very useful for benchmarking on minimal CHERI images that might
not contain libc++ (I have since added libc++ by default but this change
is still useful).